### PR TITLE
Item merge config switch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ end
 # testing
 group :test do
 	gem 'rspec'
-#	gem 'ruby-debug19'
 	gem 'simplecov', :require => false
 	gem 'simplecov-rcov', :require => false
 #  gem 'jettywrapper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.25.1)
-    mini_portile (0.5.3)
+    mini_portile (0.6.0)
     mods (0.0.23)
       iso-639
       nokogiri
@@ -75,10 +75,9 @@ GEM
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.8.0)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
-    nokogiri (1.6.1-java)
-      mini_portile (~> 0.5.0)
+    nokogiri (1.6.2.1)
+      mini_portile (= 0.6.0)
+    nokogiri (1.6.2.1-java)
     nom-xml (0.5.1)
       activesupport
       i18n
@@ -114,7 +113,7 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (0.0.24)
+    stanford-mods (0.0.25)
       mods
     term-ansicolor (1.3.0)
       tins (~> 1.0)

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,7 @@
 = gdor-indexer
 
+{<img src="https://gemnasium.com/sul-dlss/gdor-indexer.png" alt="Dependency Status" />}[https://gemnasium.com/sul-dlss/gdor-indexer] 
+
 Code to harvest DOR druids via OAI, mods from PURL, and use it to index items into the Searchworks index.
 
 Relationship used for OAI harvest:  "is_member_of_collection_ww121ss5000"
@@ -7,14 +9,16 @@ Relationship used for OAI harvest:  "is_member_of_collection_ww121ss5000"
 
 == install steps
 
-You must use jruby in 1.9 compatibility mode to run this app. Version 1.6.8 is known to work. An rvmrc file with the below is known to work :
-export JRUBY_OPTS="--1.9"
-rvm use jruby-1.6.8
+You must use jruby in 1.9 compatibility mode to run this app. Version 1.7.9 is known to work. An rvmrc file with the below is known to work :
+  # export JRUBY_OPTS="--1.9"  # this is the default so it is no longer needed
+  rvm use jruby-1.7.9
+  
+  bundle install
 
 You must also clone the solrmarc code from git (for merged records)
-clone /afs/ir/dev/dlss/git/searchworks/solrmarc-sw.git
-run 'ant dist_site'
-set dist_dir to the path of the dist directory that is created, like dist_dir: ./solrmarc-sw/dist
+  clone /afs/ir/dev/dlss/git/searchworks/solrmarc-sw.git
+  run 'ant dist_site'
+  set dist_dir to the path of the dist directory that is created, like dist_dir: ./solrmarc-sw/dist
 
 == Usage
 create a collection config file based on spec/config/walters_integration_spec.yml in the config/collections folder

--- a/indexer.rb
+++ b/indexer.rb
@@ -101,39 +101,41 @@ class Indexer < Harvestdor::Indexer
         fields_to_add[:file_id] = sdb.file_ids unless !sdb.file_ids  # defined in public_xml_fields
 
         ckey = sdb.catkey
-        if ckey && config.merge_policy == 'never'
-          logger.warn("#{druid} indexed from MODS; has ckey #{ckey} but merge_policy is 'never'")
-        elsif ckey
-          logger.info "item #{druid} merged into #{ckey}"
-          add_coll_info fields_to_add, sdb.coll_druids_from_rels_ext # defined in public_xml_fields
-          @validation_messages = validate_item(druid, fields_to_add)
-          require 'record_merger'
-          merged = RecordMerger.merge_and_index(ckey, fields_to_add)
-          if !merged
-            if config.merge_policy == 'always'
-              logger.error("#{druid} NOT INDEXED:  MARC record #{ckey} not found in SW Solr index (may be shadowed in Symphony)")
+        if ckey 
+          if config.merge_policy == 'never'
+            logger.warn("#{druid} to be indexed from MODS; has ckey #{ckey} but merge_policy is 'never'")
+            merged = false
+          else
+            add_coll_info fields_to_add, sdb.coll_druids_from_rels_ext # defined in public_xml_fields
+            @validation_messages = validate_item(druid, fields_to_add)
+            require 'record_merger'
+            merged = RecordMerger.merge_and_index(ckey, fields_to_add)
+            if merged
+              logger.info "item #{druid} merged into #{ckey}"
+              @success_count += 1
             else
-              logger.error("#{druid} indexed from MODS:  MARC record #{ckey} not found in SW Solr index (may be shadowed in Symphony)")
+              if config.merge_policy == 'always'
+                logger.error("#{druid} NOT INDEXED:  MARC record #{ckey} not found in SW Solr index (may be shadowed in Symphony) and merge_policy set to 'always'")
+                @error_count += 1
+              else
+                logger.error("#{druid} to be indexed from MODS:  MARC record #{ckey} not found in SW Solr index (may be shadowed in Symphony)")
+              end
             end
           end
         end
         
-        if merged
+        if !ckey && config.merge_policy == 'always'
+          logger.error("#{druid} NOT INDEXED:  no ckey found and merge_policy set to 'always'")
+          @error_count += 1
+        elsif !ckey || ( !merged && config.merge_policy != 'always' )
+          logger.info "indexing item #{druid} (unmerged)"
+          doc_hash = sdb.doc_hash
+          doc_hash.combine fields_to_add
+          add_coll_info doc_hash, sdb.coll_druids_from_rels_ext # defined in public_xml_fields
+          @validation_messages = validate_item(druid, doc_hash)
+          @validation_messages.concat sdb.validate_mods(druid, doc_hash)
+          solr_add(doc_hash, druid)
           @success_count += 1
-        else
-          if !ckey && !merged && config.merge_policy == 'always'
-            logger.error("#{druid} NOT INDEXED:  no ckey found and merge_policy set to 'always'")
-            @error_count += 1
-          elsif !ckey || ( !merged && config.merge_policy != 'always' )
-            logger.info "indexing item #{druid}"
-            doc_hash = sdb.doc_hash
-            doc_hash.combine fields_to_add
-            add_coll_info doc_hash, sdb.coll_druids_from_rels_ext # defined in public_xml_fields
-            @validation_messages = validate_item(druid, doc_hash)
-            @validation_messages.concat sdb.validate_mods(druid, doc_hash)
-            solr_add(doc_hash, druid)
-            @success_count += 1
-          end
         end
       rescue => e
         @error_count += 1

--- a/indexer.rb
+++ b/indexer.rb
@@ -40,8 +40,14 @@ class Indexer < Harvestdor::Indexer
   def config
     Indexer.config
   end
+  def self.logger
+    dir = config.log_dir ||= 'logs'
+    fname = config.log_name
+    Dir.mkdir(dir) unless File.directory?(dir)
+    @@logger ||= Logger.new(File.join(dir, config.log_name), 'daily')
+  end  
   def logger
-    @logger ||= load_logger(config.log_dir ||= 'logs', config.log_name)
+    @logger = Indexer.logger
   end
   
   # per this Indexer's config options 

--- a/lib/gdor_mods_fields.rb
+++ b/lib/gdor_mods_fields.rb
@@ -72,10 +72,8 @@ module GdorModsFields
     vals = @smods_rec.format ? @smods_rec.format : []
     return vals.uniq if !vals.empty?
 
-    if not @smods_rec.typeOfResource or @smods_rec.typeOfResource.length == 0
-      @logger.warn "#{@druid} has no valid typeOfResource"
-      []
-    end
+    @logger.warn "#{@druid} has no valid SearchWorks format - check <typeOfResource> and other implicated MODS elements"
+    []
   end
 
 protected

--- a/lib/record_merger.rb
+++ b/lib/record_merger.rb
@@ -28,8 +28,17 @@ class RecordMerger
   # @param [Hash<String, Object>] doc_hash_to_add - the keys are Solr field names, the values are either String or an Array of Strings
   def self.merge_and_index catkey, doc_hash_to_add
     doc = RecordMerger.fetch_sw_solr_input_doc catkey
+    if !doc
+      if Indexer.config.merge_policy == 'always'
+        Indexer.logger.error("#{doc_hash_to_add[:druid]} NOT INDEXED:  MARC record #{catkey} not found in SW Solr index (may be shadowed in Symphony)")
+      else
+        Indexer.logger.error("#{doc_hash_to_add[:druid]} indexed from MODS:  MARC record #{catkey} not found in SW Solr index (may be shadowed in Symphony)")
+      end
+      return false
+    end
     add_hash_to_solr_input_doc(doc, doc_hash_to_add)
     solrj.add_doc_to_ix(doc, catkey)
+    true
   end
   
   # cache SolrJWrapper object at class level

--- a/lib/record_merger.rb
+++ b/lib/record_merger.rb
@@ -28,14 +28,7 @@ class RecordMerger
   # @param [Hash<String, Object>] doc_hash_to_add - the keys are Solr field names, the values are either String or an Array of Strings
   def self.merge_and_index catkey, doc_hash_to_add
     doc = RecordMerger.fetch_sw_solr_input_doc catkey
-    if !doc
-      if Indexer.config.merge_policy == 'always'
-        Indexer.logger.error("#{doc_hash_to_add[:druid]} NOT INDEXED:  MARC record #{catkey} not found in SW Solr index (may be shadowed in Symphony)")
-      else
-        Indexer.logger.error("#{doc_hash_to_add[:druid]} indexed from MODS:  MARC record #{catkey} not found in SW Solr index (may be shadowed in Symphony)")
-      end
-      return false
-    end
+    return false if !doc
     add_hash_to_solr_input_doc(doc, doc_hash_to_add)
     solrj.add_doc_to_ix(doc, catkey)
     true

--- a/spec/unit/indexer_spec.rb
+++ b/spec/unit/indexer_spec.rb
@@ -123,23 +123,8 @@ describe Indexer do
               Indexer.config[:merge_policy] = 'always'
               RecordMerger.should_receive(:fetch_sw_solr_input_doc).with(@ckey).and_return(nil)
               RecordMerger.should_receive(:merge_and_index).with(@ckey, instance_of(Hash)).and_call_original
-              @indexer.logger.should_receive(:error).with("#{@fake_druid} NOT INDEXED:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
+              @indexer.logger.should_receive(:error).with("#{@fake_druid} NOT INDEXED:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony) and merge_policy set to 'always'")
               @indexer.solr_client.should_not_receive(:add)
-              @indexer.index_item @fake_druid
-            end
-          end
-          context "merge_policy 'when_possible'" do
-            it "uses RecordMerger if SW Solr index has record" do
-              Indexer.config[:merge_policy] = 'when_possible'
-              RecordMerger.should_receive(:merge_and_index).with(@ckey, instance_of(Hash))
-              @indexer.index_item @fake_druid
-            end
-            it "falls back to MODS with error message if no record in SW Solr index" do
-              Indexer.config[:merge_policy] = 'when_possible'
-              RecordMerger.stub(:fetch_sw_solr_input_doc).with(@ckey).and_return(nil)
-              RecordMerger.should_receive(:merge_and_index).with(@ckey, instance_of(Hash)).and_call_original
-              @indexer.logger.should_receive(:error).with("#{@fake_druid} indexed from MODS:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
-              @indexer.solr_client.should_receive(:add)
               @indexer.index_item @fake_druid
             end
           end
@@ -147,7 +132,7 @@ describe Indexer do
             it "does not use RecordMerger and prints warning message" do
               Indexer.config[:merge_policy] = 'never'
               RecordMerger.should_not_receive(:merge_and_index)
-              @indexer.logger.should_receive(:warn).with("#{@fake_druid} indexed from MODS; has ckey #{@ckey} but merge_policy is 'never'")
+              @indexer.logger.should_receive(:warn).with("#{@fake_druid} to be indexed from MODS; has ckey #{@ckey} but merge_policy is 'never'")
               @indexer.solr_client.should_receive(:add)
               @indexer.index_item @fake_druid
             end
@@ -162,7 +147,7 @@ describe Indexer do
               Indexer.config[:merge_policy] = nil
               RecordMerger.stub(:fetch_sw_solr_input_doc).with(@ckey).and_return(nil)
               RecordMerger.should_receive(:merge_and_index).with(@ckey, instance_of(Hash)).and_call_original
-              @indexer.logger.should_receive(:error).with("#{@fake_druid} indexed from MODS:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
+              @indexer.logger.should_receive(:error).with("#{@fake_druid} to be indexed from MODS:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
               @indexer.solr_client.should_receive(:add)
               @indexer.index_item @fake_druid
             end
@@ -180,13 +165,6 @@ describe Indexer do
             @indexer.solr_client.should_not_receive(:add)
             @indexer.index_item @fake_druid
           end
-          it "merge_policy 'when_possible' uses the MODS without error message" do
-            Indexer.config[:merge_policy] = 'when_possible'
-            RecordMerger.should_not_receive(:merge_and_index)
-            @indexer.logger.should_not_receive(:error)
-            @indexer.solr_client.should_receive(:add)
-            @indexer.index_item @fake_druid
-          end
           it "merge_policy 'never' uses the MODS without error message" do
             Indexer.config[:merge_policy] = 'never'
             RecordMerger.should_not_receive(:merge_and_index)
@@ -200,7 +178,7 @@ describe Indexer do
             @indexer.solr_client.should_receive(:add)
             @indexer.index_item @fake_druid
           end
-        end # no catkey        
+        end # no catkey
       end # config.merge_policy
     end # merge or not?
 

--- a/spec/unit/indexer_spec.rb
+++ b/spec/unit/indexer_spec.rb
@@ -121,7 +121,7 @@ describe Indexer do
               Indexer.config[:merge_policy] = 'always'
               RecordMerger.should_receive(:fetch_sw_solr_input_doc).with(@ckey).and_return(nil)
               RecordMerger.should_receive(:merge_and_index).with(@ckey, instance_of(Hash)).and_call_original
-              @indexer.logger.should_receive(:error).with("oo000oo0000 NOT INDEXED:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
+              @indexer.logger.should_receive(:error).with("#{@fake_druid} NOT INDEXED:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
               @indexer.solr_client.should_not_receive(:add)
               @indexer.index_item @fake_druid
             end
@@ -136,7 +136,7 @@ describe Indexer do
               Indexer.config[:merge_policy] = 'when_possible'
               RecordMerger.stub(:fetch_sw_solr_input_doc).with(@ckey).and_return(nil)
               RecordMerger.should_receive(:merge_and_index).with(@ckey, instance_of(Hash)).and_call_original
-              @indexer.logger.should_receive(:error).with("oo000oo0000 indexed from MODS:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
+              @indexer.logger.should_receive(:error).with("#{@fake_druid} indexed from MODS:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
               @indexer.solr_client.should_receive(:add)
               @indexer.index_item @fake_druid
             end
@@ -145,7 +145,7 @@ describe Indexer do
             it "does not use RecordMerger and prints warning message" do
               Indexer.config[:merge_policy] = 'never'
               RecordMerger.should_not_receive(:merge_and_index)
-              @indexer.logger.should_receive(:warn).with("oo000oo0000 indexed from MODS; has ckey #{@ckey} but merge_policy is 'never'")
+              @indexer.logger.should_receive(:warn).with("#{@fake_druid} indexed from MODS; has ckey #{@ckey} but merge_policy is 'never'")
               @indexer.solr_client.should_receive(:add)
               @indexer.index_item @fake_druid
             end
@@ -160,7 +160,7 @@ describe Indexer do
               Indexer.config[:merge_policy] = nil
               RecordMerger.stub(:fetch_sw_solr_input_doc).with(@ckey).and_return(nil)
               RecordMerger.should_receive(:merge_and_index).with(@ckey, instance_of(Hash)).and_call_original
-              @indexer.logger.should_receive(:error).with("oo000oo0000 indexed from MODS:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
+              @indexer.logger.should_receive(:error).with("#{@fake_druid} indexed from MODS:  MARC record #{@ckey} not found in SW Solr index (may be shadowed in Symphony)")
               @indexer.solr_client.should_receive(:add)
               @indexer.index_item @fake_druid
             end
@@ -174,7 +174,7 @@ describe Indexer do
           it "merge_policy 'always' doesn't use the MODS and prints error message" do
             Indexer.config[:merge_policy] = 'always'
             RecordMerger.should_not_receive(:merge_and_index)
-            @indexer.logger.should_receive(:error).with("oo000oo0000 NOT INDEXED:  no ckey found and merge_policy set to 'always'")
+            @indexer.logger.should_receive(:error).with("#{@fake_druid} NOT INDEXED:  no ckey found and merge_policy set to 'always'")
             @indexer.solr_client.should_not_receive(:add)
             @indexer.index_item @fake_druid
           end

--- a/spec/unit/indexer_spec.rb
+++ b/spec/unit/indexer_spec.rb
@@ -72,10 +72,12 @@ describe Indexer do
         ckey = '666'
         sdb = double
         sdb.stub(:catkey).and_return(ckey)
+        sdb.stub(:doc_hash).and_return({})
         sdb.stub(:coll_druids_from_rels_ext)
         sdb.stub(:public_xml)
         sdb.stub(:display_type)
         sdb.stub(:file_ids)
+        sdb.stub(:validate_mods).and_return([])
         SolrDocBuilder.stub(:new).and_return(sdb)
         RecordMerger.should_receive(:merge_and_index).with(ckey, instance_of(Hash))
         @indexer.index_item @fake_druid
@@ -269,11 +271,14 @@ describe Indexer do
         @sdb = double
         @sdb.stub(:catkey).and_return(@ickey)
         @sdb.stub(:coll_druids_from_rels_ext).and_return(['foo'])
+        @sdb.stub(:doc_hash).and_return({})
         @sdb.stub(:display_type).and_return('fiddle')
         @sdb.stub(:file_ids).and_return(['dee', 'dum'])
+        @sdb.stub(:validate_mods).and_return([])
         SolrDocBuilder.stub(:new).and_return(@sdb)
         @indexer.stub(:identity_md_obj_label).with('foo').and_return('bar')
         @indexer.stub(:coll_catkey).and_return(nil)
+        Indexer.config[:merge_policy] = nil
       end
       it "calls RecordMerger.merge_and_index with gdor fields and item specific fields" do
         RecordMerger.should_receive(:merge_and_index).with(@ickey, hash_including(:display_type => 'fiddle',


### PR DESCRIPTION
For #2 -  item-level merge branch.

Add merge_policy switch for item level merge and add fallback behavior to use MODS when no MARC available.

Also manually applies updates to master branch (SW format logging, gemnasium bad, stanford-mods upgrade)

@lmcglohon 
