### PR TITLE
fix indexed coll rec check - item merge branch

### DIFF
--- a/indexer.rb
+++ b/indexer.rb
@@ -326,7 +326,7 @@ class Indexer < Harvestdor::Indexer
       params[:id] = coll_rec_id
       resp = solr_client.get 'select', :params => params
       resp['response']['docs'].each do |doc|
-        if doc['url_fulltext'] and doc['url_fulltext'].to_s.include?('http://purl.stanford.edu/' + doc['id'])
+        if doc['url_fulltext'] and doc['url_fulltext'].to_s.include?('http://purl.stanford.edu/' + coll_druid_from_config)
           num_found += 1
         end
       end


### PR DESCRIPTION
Finally worked out why the stupid counts were off -- merged coll recs weren't checking for the correct purl!
