### PR TITLE
bump stanford-mods to version 0.0.27

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (0.0.26)
+    stanford-mods (0.0.27)
       mods
     term-ansicolor (1.3.0)
       tins (~> 1.0)


### PR DESCRIPTION
 to get more genre values mapped to Book.

See sul-dlss/stanford-mods#7.

@lmcglohon 
