### PR TITLE
adjust cap deploy to not use defunct scripts

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,7 @@ set :user, "lyberadmin"
 set :deploy_to, "/home/#{fetch(:user)}/#{fetch(:application)}"
 
 set :linked_dirs, %w(logs config/collections tmp solrmarc-sw)
-set :linked_files, %w{.ruby-version config/solr.yml bin/index_prod_collections.sh bin/index_stage_collections.sh bin/index-prod-image.sh bin/index-prod-hydrus.sh}
+set :linked_files, %w{.ruby-version config/solr.yml bin/index-prod-image.sh bin/index-prod-hydrus.sh}
 
 set :stages, %W(dev stage prod swuird)
 


### PR DESCRIPTION
for INDEX-135,   removing defunct scripts from bin directory.

@lmcglohon 
